### PR TITLE
HealthBar placement fixes

### DIFF
--- a/Configuration/ModConfig.cs
+++ b/Configuration/ModConfig.cs
@@ -15,7 +15,7 @@ namespace VisibleStamina.Configuration
     {
         public int HorizontalMargin { get; set; } = 16;
         public int VerticalMargin { get; set; } = 8;
-        public int Spacing { get; set; } = 56;
+        public int Spacing { get; set; } = 16;
         public int BleedHealth { get; set; } = 10;
         public int SweatEnergy { get; set; } = 20;
         public int BarFillYOffset { get; set; } = 12;

--- a/Ui/Hud.cs
+++ b/Ui/Hud.cs
@@ -39,7 +39,7 @@ namespace VisibleStamina.Ui
             EnergyBar.Position = position + GetShakeOffset(Game1.staminaShakeTimer > 0);
             EnergyBar.Update();
 
-            position = new(titleSafeArea.Right - EnergyBar.Size.X - Config.HorizontalMargin, titleSafeArea.Bottom - EnergyBar.Size.Y - Config.VerticalMargin - Config.Spacing);
+            position = new(titleSafeArea.Right - HealthBar.Size.X - Config.HorizontalMargin, titleSafeArea.Bottom - EnergyBar.Size.Y - HealthBar.Size.Y - Config.VerticalMargin - Config.Spacing);
             HealthBar.Position = position + GetShakeOffset(Game1.hitShakeTimer > 0);
             HealthBar.Visible = Game1.showingHealth || Game1.showingHealthBar || Config.AlwaysShowHealthBar;
             HealthBar.Update();


### PR DESCRIPTION
- fix bug in HealthBar placement that was causing it to go off screen when health was greater than the default amount.

- modified interaction between HealthBar placement and spacing. spacing should now be the distance between the top of the energy bar and the bottom of the health bar.